### PR TITLE
Add min_node_count argument and test

### DIFF
--- a/lib/AnyEvent/Consul/Exec.pm
+++ b/lib/AnyEvent/Consul/Exec.pm
@@ -21,12 +21,13 @@ sub new {
     ClassName,
     slurpy Dict[
       command => Str,
-      wait    => Optional[Int],
-      dc      => Optional[Str],
-      node    => Optional[Str],
-      service => Optional[Str],
-      tag     => Optional[Str],
-      consul_args => Optional[ArrayRef],
+      wait            => Optional[Int],
+      dc              => Optional[Str],
+      node            => Optional[Str],
+      min_node_count  => Optional[Int],
+      service         => Optional[Str],
+      tag             => Optional[Str],
+      consul_args     => Optional[ArrayRef],
       map { $_ => Optional[CodeRef] } @callbacks,
     ],
   );
@@ -35,6 +36,7 @@ sub new {
   $self->{wait} //= 2;
   $self->{consul_args} //= [];
   $self->{dc_args} = $self->{dc} ? [dc => $self->{dc}] : [];
+  $self->{min_node_count} //= 0;
   return bless $self, $class;
 }
 
@@ -80,9 +82,12 @@ sub _wait_responses {
         if ($act eq 'exit') {
           $self->{_nexit}++;
           $self->{on_exit}->($node, $kv->value);
-          if ($self->{_nack} == $self->{_nexit}) {
-            # XXX super naive. there might be some that haven't acked yet
-            #     should schedule done for a lil bit in the future
+
+          # XXX super naive. there might be some that haven't acked yet
+          #     should schedule done for a lil bit in the future
+          if (   $self->{_nack} == $self->{_nexit}
+              && $self->{_nexit} >= $self->{min_node_count})
+          {
             $self->{_done} = 1;
             $self->_cleanup(sub { $self->{on_done}->() });
           }
@@ -341,6 +346,16 @@ C<-wait> option to C<consul exec>.
 The C<node>, C<service> and C<tag> each take basic regexes that will be used to
 match nodes to run the command on. See the corresponding options to C<consul exec>
 for more info.
+
+If you specify <min_node_count>, at *least* this many nodes must report in
+before we consider a job done. Without this, some nodes might report back
+results before we've seen an ack from the others, and your job may prematurely
+be canceled on those other nodes, or your on_done callback will be called
+prematurely. This is most useful if C<node> is a regex that matches an
+explicit amount of nodes, for example:
+
+    node => /^(host1|host2|host3)$/,
+    min_node_count => 3,
 
 The C<dc> option can take the name of the datacenter to run the command in. The
 exec mechanism is limited to a single datacentre. This option will cause

--- a/t/30-exec-min-nodes.t
+++ b/t/30-exec-min-nodes.t
@@ -1,0 +1,59 @@
+#!perl
+
+use 5.020;
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Exception;
+use Test::Consul 0.011;
+
+use AnyEvent;
+use AnyEvent::Consul;
+use AnyEvent::Consul::Exec;
+
+my $tc1 = eval { Test::Consul->start(enable_remote_exec => 1) };
+my $tc2 = eval { Test::Consul->start(enable_remote_exec => 1,
+                                     datacenter => $tc1->datacenter) };
+
+SKIP: {
+  skip "consul test environment not available", 1, unless $tc1 && $tc2;
+
+  $tc1->join($tc2);
+
+  my $cv = AE::cv;
+
+  my %exited;
+
+  my $e = AnyEvent::Consul::Exec->new(
+    consul_args => [ port => $tc1->port ],
+
+    node => '.*',
+    min_node_count => 2,
+
+    command => 'echo $PPID',
+
+    on_exit => sub {
+      my ($node, $rc) = @_;
+
+      $exited{$node} = $rc;
+    },
+
+    on_done => sub {
+      $cv->send;
+    },
+
+    on_error => sub {
+      diag @_;
+      $cv->send;
+    },
+  );
+
+  $e->start;
+  $cv->recv;
+
+  is($exited{$tc1->node_name}, 0, 'first node exited');
+  is($exited{$tc2->node_name}, 0, 'second node exited');
+}
+
+done_testing;


### PR DESCRIPTION
This new argument says "You must see at least this many nodes exit before you consider the job done".

This is necessary because the current logic of checking the number of nodes acked against the number of jobs exited doesn't account for a job acking and exiting before another job has even acked, which is easy to trigger.